### PR TITLE
make sensor naming configurable,add normalization

### DIFF
--- a/.env
+++ b/.env
@@ -28,19 +28,28 @@ APP_SECRET=0bfefb84fdc0d00008386d6f38c9025f
 #DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7
 DATABASE_URL=mysql://root:@database:3306/weatherStation
 ###< doctrine/doctrine-bundle ###
-# Email Configuration #
-MAILER_DSN=gmail+smtp://yoursendfromemail:yourpassword
-FROM_EMAIL=
-TO_EMAIL=
+# Email Configuration -start#
+MAILER_DSN=gmail+smtp://fromEmail:password@default
+FROM_EMAIL=fromemail
+TO_EMAIL=toemail
 EMAIL_TITLE="Weather Station Report"
 TIMEZONE="America/Toronto"
 FIRST_REPORT_TIME="07:00:00"
 SECOND_REPORT_TIME="20:00:00"
-# Email Configuration #
+# Email Configuration -end#
 
-# Reading Pruning Configuration #
+# Reading Pruning Configuration  -start#
 KEEP_RECORDS_FOR=1
-# Reading Pruning Configuration #
+# Reading Pruning Configuration -end#
+
+# Sensor naming, should start by SENSOR_ -start
+SENSOR_BEDROOM=6126
+SENSOR_BASEMENT=3026
+SENSOR_GARAGE=8166
+SENSOR_LIVING_ROOM=15043
+SENSOR_OUTSIDE=12154
+# Sensor naming -end
+
 
 
 

--- a/src/Listeners/PostListener.php
+++ b/src/Listeners/PostListener.php
@@ -172,13 +172,7 @@ class PostListener {
     private function prepareSensorData(LifecycleEventArgs $args, SensorController $sensorController): array {
         $entityManager = $args->getObjectManager();
         // Construct station IDs array.
-        $stationIDs = [
-            'outside' => $sensorController::STATION_ID_OUTSIDE,
-            'living-room' => $sensorController::STATION_ID_LIVING_ROOM,
-            'garage' => $sensorController::STATION_ID_GARAGE,
-            'bedroom' => $sensorController::STATION_ID_BEDROOM,
-            'basement' => $sensorController::STATION_ID_BASEMENT
-        ];
+        $stationIDs = SensorController::constructSensorData();
         // Remove any invalid entries before calling temp & humidity methods on an empty array.
         $prepareData = $weatherData =  [];
         foreach ($stationIDs as $room => $stationID) {


### PR DESCRIPTION
closes https://github.com/danistark1/weatherStationApiSymfony/issues/35

To add a new sensor ex name:abc id 123, add it in the config in the following format

SENSOR_ABC=123

SensorController::ConstructSensorData() will then constrauct an array of sensor in the form:

[SENSOR_ABC => 123]

getSensorByID / getSensorByName can now be called with the new configured sensor name/id.

