### PR TITLE
Fix replacing _ with - for sensor names

### DIFF
--- a/src/Controller/SensorController.php
+++ b/src/Controller/SensorController.php
@@ -280,6 +280,10 @@ class SensorController extends AbstractController {
         foreach($envArray as $key => $value) {
             $sensorConfig = str_contains($key, $lookupValue);
             if ($sensorConfig) {
+                if (str_contains($key, '_')) {
+                    // Since - is not allowed in .env file, replace anyone in $key.
+                    $key = str_replace('_', '-', $key);
+                }
                 $sensorData += [strtolower(substr($key,7, strlen($key)-7)) => $value];
             }
         }


### PR DESCRIPTION
Fix replacing _ with - for sensor names

station names configured as ABC_DEF were causing validation error in SensorController::ValidateName when the incoming sensor name was with -