### PR TITLE
Fix sensor naming with underscore not matching route

### DIFF
--- a/src/Controller/SensorController.php
+++ b/src/Controller/SensorController.php
@@ -280,10 +280,6 @@ class SensorController extends AbstractController {
         foreach($envArray as $key => $value) {
             $sensorConfig = str_contains($key, $lookupValue);
             if ($sensorConfig) {
-                if (str_contains($key, '_')) {
-                    // Since - is not allowed in .env file, replace anyone in $key.
-                    $key = str_replace('_', '-', $key);
-                }
                 $sensorData += [strtolower(substr($key,7, strlen($key)-7)) => $value];
             }
         }

--- a/tests/SensorControllerTests.php
+++ b/tests/SensorControllerTests.php
@@ -21,7 +21,7 @@ class SensorControllerTests extends AbstractControllerTest {
      * Test SensorController::getByID()
      *
      * @dataProvider provideSensorControllerData
-     * @param int $id
+     * @param int $stationID
      * @param string $expectedSensorName
      */
     public function testValidSensorControllerGetByID(int $stationID, string $expectedSensorName): void {


### PR DESCRIPTION
Fix issue with route not matching sensor with dash in name. 

NodeRed's flow will need to be updated for any sensors that has dashes in name.

