### PR TITLE
Add multi-recipient email notifications, refactor [Breaking Changes]

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -107,9 +107,15 @@
       <path value="$PROJECT_DIR$/vendor/phar-io/version" />
       <path value="$PROJECT_DIR$/vendor/phpspec/prophecy" />
       <path value="$PROJECT_DIR$/vendor/theseer/tokenizer" />
+      <path value="$PROJECT_DIR$/vendor/symfony/apache-pack" />
     </include_path>
   </component>
   <component name="PhpProjectSharedConfiguration" php_language_level="7.2">
     <option name="suggestChangeDefaultLanguageLevel" value="false" />
+  </component>
+  <component name="PhpUnit">
+    <phpunit_settings>
+      <PhpUnitSettings configuration_file_path="$PROJECT_DIR$/phpunit.xml.dist" custom_loader_path="$PROJECT_DIR$/vendor/autoload.php" use_configuration_file="true" />
+    </phpunit_settings>
   </component>
 </project>

--- a/.idea/phpunit.xml
+++ b/.idea/phpunit.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PHPUnit">
+    <option name="directories">
+      <list>
+        <option value="$PROJECT_DIR$/tests" />
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/sensorGatewayAPISymf.iml
+++ b/.idea/sensorGatewayAPISymf.iml
@@ -110,6 +110,7 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/phar-io/version" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpspec/prophecy" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/theseer/tokenizer" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/apache-pack" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "doctrine/orm": "^2.7",
         "phpdocumentor/reflection-docblock": "^5.2",
         "sensio/framework-extra-bundle": "^5.6",
+        "symfony/apache-pack": "^1.0",
         "symfony/asset": "5.1.*",
         "symfony/browser-kit": "5.1.*",
         "symfony/cache": "5.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "05906d5d5b38fa6c87ddef26d0997746",
+    "content-hash": "a0dbd80993b113ab4680258ec14588c7",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -1930,6 +1930,32 @@
                 "controllers"
             ],
             "time": "2020-08-25T19:10:18+00:00"
+        },
+        {
+            "name": "symfony/apache-pack",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/apache-pack.git",
+                "reference": "3aa5818d73ad2551281fc58a75afd9ca82622e6c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/apache-pack/zipball/3aa5818d73ad2551281fc58a75afd9ca82622e6c",
+                "reference": "3aa5818d73ad2551281fc58a75afd9ca82622e6c",
+                "shasum": ""
+            },
+            "type": "symfony-pack",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A pack for Apache support in Symfony",
+            "support": {
+                "issues": "https://github.com/symfony/apache-pack/issues",
+                "source": "https://github.com/symfony/apache-pack/tree/master"
+            },
+            "time": "2017-12-12T01:46:35+00:00"
         },
         {
             "name": "symfony/asset",
@@ -6578,5 +6604,6 @@
         "ext-iconv": "*",
         "ext-json": "*"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
 }

--- a/migrations/Version20211030030836.php
+++ b/migrations/Version20211030030836.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20211030030836 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE sensorconfiguration ADD attributes LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json)\'');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE sensorConfiguration DROP attributes');
+    }
+}

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,66 @@
+# Use the front controller as index file. It serves as a fallback solution when
+# every other rewrite/redirect fails (e.g. in an aliased environment without
+# mod_rewrite). Additionally, this reduces the matching process for the
+# start page (path "/") because otherwise Apache will apply the rewriting rules
+# to each configured DirectoryIndex file (e.g. index.php, index.html, index.pl).
+DirectoryIndex index.php
+
+# By default, Apache does not evaluate symbolic links if you did not enable this
+# feature in your server configuration. Uncomment the following line if you
+# install assets as symlinks or if you experience problems related to symlinks
+# when compiling LESS/Sass/CoffeScript assets.
+# Options +FollowSymlinks
+
+# Disabling MultiViews prevents unwanted negotiation, e.g. "/index" should not resolve
+# to the front controller "/index.php" but be rewritten to "/index.php/index".
+<IfModule mod_negotiation.c>
+    Options -MultiViews
+</IfModule>
+
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+
+    # Determine the RewriteBase automatically and set it as environment variable.
+    # If you are using Apache aliases to do mass virtual hosting or installed the
+    # project in a subdirectory, the base path will be prepended to allow proper
+    # resolution of the index.php file and to redirect to the correct URI. It will
+    # work in environments without path prefix as well, providing a safe, one-size
+    # fits all solution. But as you do not need it in this case, you can comment
+    # the following 2 lines to eliminate the overhead.
+    RewriteCond %{REQUEST_URI}::$0 ^(/.+)/(.*)::\2$
+    RewriteRule .* - [E=BASE:%1]
+
+    # Sets the HTTP_AUTHORIZATION header removed by Apache
+    RewriteCond %{HTTP:Authorization} .+
+    RewriteRule ^ - [E=HTTP_AUTHORIZATION:%0]
+
+    # Redirect to URI without front controller to prevent duplicate content
+    # (with and without `/index.php`). Only do this redirect on the initial
+    # rewrite by Apache and not on subsequent cycles. Otherwise we would get an
+    # endless redirect loop (request -> rewrite to front controller ->
+    # redirect -> request -> ...).
+    # So in case you get a "too many redirects" error or you always get redirected
+    # to the start page because your Apache does not expose the REDIRECT_STATUS
+    # environment variable, you have 2 choices:
+    # - disable this feature by commenting the following 2 lines or
+    # - use Apache >= 2.3.9 and replace all L flags by END flags and remove the
+    #   following RewriteCond (best solution)
+    RewriteCond %{ENV:REDIRECT_STATUS} =""
+    RewriteRule ^index\.php(?:/(.*)|$) %{ENV:BASE}/$1 [R=301,L]
+
+    # If the requested filename exists, simply serve it.
+    # We only want to let Apache serve files and not directories.
+    # Rewrite all other queries to the front controller.
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteRule ^ %{ENV:BASE}/index.php [L]
+</IfModule>
+
+<IfModule !mod_rewrite.c>
+    <IfModule mod_alias.c>
+        # When mod_rewrite is not available, we instruct a temporary redirect of
+        # the start page to the front controller explicitly so that the website
+        # and the generated links can still be used.
+        RedirectMatch 307 ^/$ /index.php/
+        # RedirectTemp cannot be used instead
+    </IfModule>
+</IfModule>

--- a/src/Controller/ConfigurationController.php
+++ b/src/Controller/ConfigurationController.php
@@ -114,7 +114,7 @@ class ConfigurationController extends AbstractController {
     }
 
     /**
-     * Post weatherData.
+     * Post a config.
      *
      * @Route("/weatherstation/api/config",  methods={"POST"}, name="post_config")
      * @param string $key
@@ -133,6 +133,8 @@ class ConfigurationController extends AbstractController {
     }
 
     /**
+     * Get a config.
+     *
      * @param Request $request
      * @param $key
      * @return Response
@@ -141,7 +143,11 @@ class ConfigurationController extends AbstractController {
      */
     public function getConfig(Request $request, $key): Response {
         $value = $this->configCache->getConfigKey($key);
+        if (is_array($value)) {
+            $value = implode(',', $value);
+        }
         $this->response->setContent($value);
+
         return $this->response;
     }
 

--- a/src/Entity/SensorConfigurationEntity.php
+++ b/src/Entity/SensorConfigurationEntity.php
@@ -24,7 +24,7 @@ class SensorConfigurationEntity
     private $configKey;
 
     /**
-     * @ORM\Column(type="string", length=50, nullable=true)
+     * @ORM\Column(type="string", length=250, nullable=true)
      */
     private $configValue;
 
@@ -32,11 +32,16 @@ class SensorConfigurationEntity
      * @ORM\Column(type="date")
      */
     private $configDate;
-
+    
     /**
      * @ORM\Column(type="string", length=25)
      */
     private $config_type;
+
+    /**
+     * @ORM\Column(type="json", nullable=true)
+     */
+    private $attributes = [];
 
     public function getId(): ?int
     {
@@ -87,6 +92,18 @@ class SensorConfigurationEntity
     public function setConfigType(string $config_type): self
     {
         $this->config_type = $config_type;
+
+        return $this;
+    }
+
+    public function getAttributes(): ?array
+    {
+        return $this->attributes;
+    }
+
+    public function setAttributes(?array $attributes): self
+    {
+        $this->attributes = $attributes;
 
         return $this;
     }

--- a/src/Repository/SensorConfigurationRepository.php
+++ b/src/Repository/SensorConfigurationRepository.php
@@ -42,7 +42,7 @@ class SensorConfigurationRepository extends ServiceEntityRepository {
         $weatherConfigEnt->setConfigKey($params['config_key']);
         $weatherConfigEnt->setConfigValue($params['config_value']);
         $weatherConfigEnt->setConfigType($params['config_type']);
-
+        $weatherConfigEnt->setAttributes($params['attributes']);
         $dt = SensorDateTime::dateNow();
         $weatherConfigEnt->setConfigDate($dt);
 
@@ -55,6 +55,17 @@ class SensorConfigurationRepository extends ServiceEntityRepository {
         }
         $em->flush();
         return $result;
+    }
+
+    public function getConfigAttributes(string $lookupKey) {
+        $dbValue = false;
+        $result = parent::findBy(['configKey' => $lookupKey],[], 1);
+        // var_dump($result);
+        if (is_array($result) && !empty($result)) {
+            $dbValue = $result[0]->getAttributes();
+        }
+
+        return $dbValue;
     }
 
     /**
@@ -100,6 +111,7 @@ class SensorConfigurationRepository extends ServiceEntityRepository {
         return $dbValue;
         //return isset($value[0]) ? $value[0]->getConfigValue() : [];
     }
+
 
     // /**
     //  * @return WeatherConfiguration[] Returns an array of WeatherConfiguration objects

--- a/src/SensorConfiguration.php
+++ b/src/SensorConfiguration.php
@@ -6,8 +6,9 @@ use SplFileInfo;
 //include('../config.php');
 
 /**
- * Class WeatherConfiguration
+ * Class SensorConfiguration
  *
+ * @deprecated use SensorCacheHandler.
  * @package App
  */
 class SensorConfiguration {

--- a/symfony.lock
+++ b/symfony.lock
@@ -218,6 +218,18 @@
             "config/packages/sensio_framework_extra.yaml"
         ]
     },
+    "symfony/apache-pack": {
+        "version": "1.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "master",
+            "version": "1.0",
+            "ref": "9d254a22efca7264203eea98b866f16f944b2f09"
+        },
+        "files": [
+            "./public/.htaccess"
+        ]
+    },
     "symfony/asset": {
         "version": "v5.1.8"
     },


### PR DESCRIPTION
closes https://github.com/danistark1/sensorGatewayAPISymf/issues/134

Backup db, run composer & doctrine migrate to update db with new changes.

Adds multi-recipeint email support

- add new JSON attributes field to sensorconfiguration table
- sensorconfiguration.weatherReport-toEmail now support multiple email configuration in sensorconfiguration.attributes field
["email1","email2","email3",...]
- update sensorconfiguration.configvalue size from 50 to 250 
- SensorCacheHandler@getConfigKey will now try to get the config's value from sensorconfiguration.config_value if not found, will try to locate the value in sensorconfiguration.attributes
- Refactor PostListener